### PR TITLE
Update the faker dev dependency to latest version

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("timecop")
   s.add_development_dependency("guard-rspec")
   s.add_development_dependency("byebug")
-  s.add_development_dependency("faker")
+  s.add_development_dependency("faker", "> 2.7")
   s.add_development_dependency("factory_bot")
 end
 

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
 
     firstname { Faker::Name.first_name }
     lastname { Faker::Name.last_name }
-    email { Faker::Internet.safe_email("#{Time.new.to_i.to_s[-5..-1]}#{(0..3).map { (65 + rand(26)).chr }.join}") }
+    email { Faker::Internet.safe_email(name: "#{Time.new.to_i.to_s[-5..-1]}#{(0..3).map { (65 + rand(26)).chr }.join}") }
   end
 end

--- a/spec/lib/hubspot/contact_spec.rb
+++ b/spec/lib/hubspot/contact_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hubspot::Contact do
     context 'without properties' do
       cassette
 
-      let(:email) { Faker::Internet.safe_email("#{(0..3).map { (65 + rand(26)).chr }.join}#{Time.new.to_i.to_s[-5..-1]}") }
+      let(:email) { Faker::Internet.safe_email(name: "#{(0..3).map { (65 + rand(26)).chr }.join}#{Time.new.to_i.to_s[-5..-1]}") }
       subject { described_class.create email }
 
       it 'creates a new contact' do
@@ -56,7 +56,7 @@ RSpec.describe Hubspot::Contact do
     context 'with properties' do
       cassette
 
-      let(:email) { Faker::Internet.safe_email("#{(0..3).map { (65 + rand(26)).chr }.join}#{Time.new.to_i.to_s[-5..-1]}") }
+      let(:email) { Faker::Internet.safe_email(name: "#{(0..3).map { (65 + rand(26)).chr }.join}#{Time.new.to_i.to_s[-5..-1]}") }
       let(:firstname) { "Allison" }
       let(:properties) { { firstname: firstname } }
 


### PR DESCRIPTION
The faker gem updated the method definition of `Faker::Internet.safe_email` in v2.8. Update the usage of that method and update the gemspec to require a version > 2.7.